### PR TITLE
Fix PDF text extraction

### DIFF
--- a/backend/services/document_service.py
+++ b/backend/services/document_service.py
@@ -84,7 +84,9 @@ class DocumentService:
             reader = PdfReader(str(file_path))
             text = ""
             for page in reader.pages:
-                text += page.extract_text() + "\n"
+                page_text = page.extract_text()
+                if page_text:
+                    text += page_text + "\n"
             return text
         except Exception as e:
             print(f"Error extracting PDF text: {str(e)}")


### PR DESCRIPTION
## Summary
- handle pages without text when extracting PDF content

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686f579ec7948329b521f25d27ffb225