### PR TITLE
Enable BREX rule defaults and validation

### DIFF
--- a/backend/default_brex_rules.yaml
+++ b/backend/default_brex_rules.yaml
@@ -1,0 +1,35 @@
+title:
+  required: true
+  maxLength: 100
+  pattern: "^[A-Za-z0-9\\s\\-_]+$"
+dmc:
+  required: true
+  pattern: "^DMC-[A-Z0-9\\-]+$"
+content:
+  required: true
+  minLength: 10
+  maxLength: 50000
+illustrations:
+  maxCount: 50
+  allowedFormats:
+    - jpg
+    - jpeg
+    - png
+    - gif
+    - svg
+tables:
+  maxColumns: 20
+  maxRows: 200
+references:
+  validateDMRefs: true
+  validateICNRefs: true
+  allowBrokenRefs: false
+security:
+  allowedClassifications:
+    - UNCLASSIFIED
+    - CONFIDENTIAL
+    - SECRET
+  requireWatermark: false
+ste:
+  minScore: 0.85
+  warnBelowScore: 0.90

--- a/frontend/src/components/BREXDesigner.js
+++ b/frontend/src/components/BREXDesigner.js
@@ -32,6 +32,19 @@ const BREXDesigner = () => {
     }
   };
 
+  const loadDefaultBREXRules = async () => {
+    try {
+      const response = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/brex-default`);
+      if (response.ok) {
+        const rules = await response.json();
+        setBrexRules(rules);
+        setYamlContent(YAML.stringify(rules, { indent: 2 }));
+      }
+    } catch (error) {
+      console.error('Error loading default BREX rules:', error);
+    }
+  };
+
   const getDefaultBREXRules = () => ({
     title: {
       required: true,
@@ -217,6 +230,12 @@ const BREXDesigner = () => {
             className={`aquila-button-secondary ${isEditingYaml ? 'bg-aquila-cyan text-white' : ''}`}
           >
             YAML
+          </button>
+          <button
+            onClick={loadDefaultBREXRules}
+            className="aquila-button-secondary"
+          >
+            Load Defaults
           </button>
           <button
             onClick={saveBREXRules}

--- a/tests/test_brex_validation.py
+++ b/tests/test_brex_validation.py
@@ -1,0 +1,22 @@
+import pytest
+from backend.server import DEFAULT_BREX_RULES, validate_module_dict, ValidationStatus
+
+
+def test_default_rules_loaded():
+    assert DEFAULT_BREX_RULES["title"]["required"] is True
+    assert "pattern" in DEFAULT_BREX_RULES["dmc"]
+
+
+def test_validate_module_dict():
+    module = {
+        "title": "",
+        "dmc": "BAD-1",
+        "content": "short",
+        "ste_score": 0.8,
+        "security_level": "CONFIDENTIAL",
+    }
+    status, errors = validate_module_dict(module, DEFAULT_BREX_RULES)
+    assert status == ValidationStatus.RED
+    assert "Title is required" in errors
+    assert any("DMC" in e for e in errors)
+    assert "Content below minimum length" in errors


### PR DESCRIPTION
## Summary
- load default BREX rules from `backend/default_brex_rules.yaml`
- allow partial updates of settings and expose `/brex-default` endpoint
- add BREX-based validation logic
- let the UI load/reset default rules from the backend
- test BREX validation helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871177b7ec48329aec7adf3e166c815