### PR TITLE
Implement publishing and local provider

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -42,3 +42,7 @@ jinja2>=3.1.0
 python-docx>=1.2.0
 pdf2image>=1.17.0
 redis>=5.0.0
+sentence-transformers>=5.0.0
+language-tool-python>=2.7.0
+torch>=2.1.0
+torchvision>=0.22.1

--- a/backend/server.py
+++ b/backend/server.py
@@ -546,13 +546,18 @@ async def publish_publication_module(pm_code: str, publish_options: Dict[str, An
         if not pm:
             raise HTTPException(404, "Publication module not found")
         
-        # This would implement the full publication process
-        # For now, return success
+        pm_obj = PublicationModule(**pm)
+        formats = publish_options.get("formats", ["xml"])
+        variants = publish_options.get("variants", ["verbatim"])
+        package_path = await document_service.publish_publication_module(
+            pm_obj, db, formats=formats, variants=variants
+        )
         return {
             "message": "Publication module published successfully",
             "pm_code": pm_code,
-            "formats": publish_options.get("formats", ["xml"]),
-            "variants": publish_options.get("variants", ["verbatim"])
+            "package": str(package_path),
+            "formats": formats,
+            "variants": variants,
         }
     except Exception as e:
         logger.error(f"Error publishing publication module: {str(e)}")

--- a/backend/templates/data_module.html.j2
+++ b/backend/templates/data_module.html.j2
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>{{ module.title }}</title>
+</head>
+<body>
+<h1>{{ module.title }}</h1>
+<pre>{{ module.content }}</pre>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- enhance `publish_publication_module` to build an export package
- add publication compilation logic to `DocumentService`
- overhaul local provider to use sentence transformers and torchvision
- add HTML template and export path
- update backend requirements

## Testing
- `pip install -r backend/requirements.txt --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687216e477e0832995cb64e22f552853