### PR TITLE
Add publication module publishing support

### DIFF
--- a/tests/test_document_service.py
+++ b/tests/test_document_service.py
@@ -8,7 +8,11 @@ from docx import Document as DocxDocument
 from reportlab.pdfgen import canvas
 
 from backend.services.document_service import DocumentService
-from backend.models.document import UploadedDocument
+from backend.models.document import UploadedDocument, DataModule, PublicationModule
+from backend.models.base import DMTypeEnum
+import asyncio
+import hashlib
+import zipfile
 
 
 def create_docx(path: Path, text: str):
@@ -59,3 +63,61 @@ def test_extract_pdf_images():
         for icn in images:
             assert Path(icn.file_path).exists()
             assert icn.width > 0 and icn.height > 0
+
+
+class FakeCursor:
+    def __init__(self, docs):
+        self.docs = docs
+
+    async def to_list(self, _):
+        return self.docs
+
+
+class FakeCollection:
+    def __init__(self, docs):
+        self.docs = docs
+
+    def find(self, query):
+        dms = [dm.dict() for dm in self.docs if dm.dmc in query["dmc"]["$in"]]
+        return FakeCursor(dms)
+
+
+class FakeDB:
+    def __init__(self, docs):
+        self.data_modules = FakeCollection(docs)
+
+
+def test_publish_publication_module(tmp_path):
+    dm1 = DataModule(
+        dmc="DMC-TEST-0001",
+        title="Test",
+        dm_type=DMTypeEnum.GEN,
+        info_variant="00",
+        content="Hello",
+        source_document_id="doc1",
+    )
+    dm2 = DataModule(
+        dmc="DMC-TEST-0002",
+        title="Test",
+        dm_type=DMTypeEnum.GEN,
+        info_variant="01",
+        content="World",
+        source_document_id="doc1",
+    )
+
+    pm = PublicationModule(pm_code="PM1", title="PM", dm_list=[dm1.dmc, dm2.dmc])
+    service = DocumentService(upload_path=tmp_path)
+    db = FakeDB([dm1, dm2])
+
+    package = asyncio.run(
+        service.publish_publication_module(
+            pm, db, formats=["xml", "html", "pdf"], variants=["00", "01"]
+        )
+    )
+
+    assert package.exists()
+    with zipfile.ZipFile(package) as z:
+        names = z.namelist()
+        assert f"{dm1.dmc}_{dm1.info_variant}.xml" in names
+        assert f"{dm1.dmc}_{dm1.info_variant}.html" in names
+        assert f"{dm1.dmc}_{dm1.info_variant}.pdf" in names


### PR DESCRIPTION
## Summary
- wire up frontend PublishModal to call the backend publish endpoint
- enhance `publish_publication_module` with HTML/PDF/XML generation and error handling
- test publish workflow via a fake DB cursor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68722839e70c8329858fb99342b8421e