### PR TITLE
Add BREX/XSD validation logic and tests

### DIFF
--- a/tests/test_brex_validation.py
+++ b/tests/test_brex_validation.py
@@ -1,5 +1,9 @@
 import pytest
-from backend.server import DEFAULT_BREX_RULES, validate_module_dict, ValidationStatus
+from backend.server import (
+    DEFAULT_BREX_RULES,
+    validate_module_dict,
+    ValidationStatus,
+)
 
 
 def test_default_rules_loaded():
@@ -7,7 +11,7 @@ def test_default_rules_loaded():
     assert "pattern" in DEFAULT_BREX_RULES["dmc"]
 
 
-def test_validate_module_dict():
+def test_validate_module_dict_failure():
     module = {
         "title": "",
         "dmc": "BAD-1",
@@ -15,8 +19,29 @@ def test_validate_module_dict():
         "ste_score": 0.8,
         "security_level": "CONFIDENTIAL",
     }
-    status, errors = validate_module_dict(module, DEFAULT_BREX_RULES)
+    status, errors, brex_valid, xsd_valid = validate_module_dict(module, DEFAULT_BREX_RULES)
     assert status == ValidationStatus.RED
+    assert brex_valid is False
+    assert xsd_valid is False  # missing required fields for XSD
     assert "Title is required" in errors
     assert any("DMC" in e for e in errors)
     assert "Content below minimum length" in errors
+
+
+def test_validate_module_dict_success(tmp_path):
+    module = {
+        "dmc": "DMC-TEST-00-000-00-00-00-00-00-000-A-A-00-00-00",
+        "title": "Valid Module",
+        "dm_type": "GEN",
+        "info_variant": "00",
+        "content": "Valid content for testing",
+        "source_document_id": "doc1",
+        "ste_score": 0.95,
+        "security_level": "UNCLASSIFIED",
+    }
+
+    status, errors, brex_valid, xsd_valid = validate_module_dict(module, DEFAULT_BREX_RULES)
+    assert status == ValidationStatus.GREEN
+    assert brex_valid is True
+    assert xsd_valid is True
+    assert errors == []


### PR DESCRIPTION
## Summary
- extend `validate_module_dict` to run both BREX rule checks and XSD validation
- update validation endpoint to store `brex_valid` and `xsd_valid` on `DataModule`
- add unit tests for validation success and failure scenarios
- install test dependencies

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68722a99f13083298cbde3cebaf5533d