### PR TITLE
Improve PDF image OCR extraction

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -41,6 +41,7 @@ markdown>=3.5.0
 jinja2>=3.1.0
 python-docx>=1.2.0
 pdf2image>=1.17.0
+pytesseract>=0.3.13
 redis>=5.0.0
 transformers>=4.40.1
 torch>=2.1.0


### PR DESCRIPTION
## Summary
- add `pytesseract` requirement
- add optional notifier and OCR text extraction for PDF pages
- use OCR text as caption when extracting images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687235f60b20832985409774c0ae99c2