### PR TITLE
Improve publication module PDF generation

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -691,13 +691,16 @@ async def publish_publication_module(
         pm_obj = PublicationModule(**pm)
         formats = publish_options.get("formats", ["xml"])
         variants = publish_options.get("variants", ["verbatim"])
-        package_path = await document_service.publish_publication_module(
+        publish_result = await document_service.publish_publication_module(
             pm_obj, db, formats=formats, variants=variants
         )
+        package_path = publish_result["package"]
+        errors = publish_result.get("errors", [])
         return {
             "message": "Publication module published successfully",
             "pm_code": pm_code,
             "package": str(package_path),
+            "errors": errors,
             "formats": formats,
             "variants": variants,
         }

--- a/tests/test_api_workflows.py
+++ b/tests/test_api_workflows.py
@@ -125,4 +125,6 @@ def test_validation_and_publish(tmp_path):
         headers=headers,
     )
     assert r.status_code == 200
-    assert os.path.exists(r.json()["package"])
+    resp = r.json()
+    assert os.path.exists(resp["package"])
+    assert resp.get("errors") == []

--- a/tests/test_document_service.py
+++ b/tests/test_document_service.py
@@ -110,12 +110,14 @@ def test_publish_publication_module(tmp_path):
     service = DocumentService(upload_path=tmp_path)
     db = FakeDB([dm1, dm2])
 
-    package = asyncio.run(
+    result = asyncio.run(
         service.publish_publication_module(
             pm, db, formats=["xml", "html", "pdf"], variants=["00", "01"]
         )
     )
 
+    package = result["package"]
+    assert result["errors"] == []
     assert package.exists()
     with zipfile.ZipFile(package) as z:
         names = z.namelist()


### PR DESCRIPTION
## Summary
- add `_render_pdf` helper to `DocumentService`
- include images and a styled layout when generating PDFs
- return export errors to callers
- expose errors in `/api/publication-modules/{pm_code}/publish`
- update tests for new return type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68724971b9b08329bfd45ede5363fa35