### PR TITLE
Fix .env loading in backend

### DIFF
--- a/backend/ai_providers/openai_provider.py
+++ b/backend/ai_providers/openai_provider.py
@@ -21,9 +21,10 @@ from .base import (
 )
 
 # Ensure environment variables are loaded even if the server did not call
-# ``load_dotenv`` for some reason. This uses the ``backend/.env`` file relative
-# to this provider module.
-load_dotenv(Path(__file__).resolve().parents[1] / ".env", override=False)
+# ``load_dotenv`` for some reason. We use ``override=True`` so that values in
+# ``backend/.env`` replace any existing environment variables that may be empty
+# in the current execution environment.
+load_dotenv(Path(__file__).resolve().parents[1] / ".env", override=True)
 
 
 class OpenAITextProvider(TextProvider):

--- a/backend/server.py
+++ b/backend/server.py
@@ -46,7 +46,12 @@ from .services.document_service import DocumentService
 
 # Load environment variables
 ROOT_DIR = Path(__file__).parent
-load_dotenv(ROOT_DIR / ".env")
+# Always load environment variables from ``backend/.env``. ``override=True``
+# ensures the values from the file replace any existing environment variables
+# that may have been defined but left empty by the execution environment. This
+# prevents spurious "<VAR> environment variable not set" errors when a blank
+# variable already exists.
+load_dotenv(ROOT_DIR / ".env", override=True)
 
 # MongoDB connection
 mongo_url = os.environ["MONGO_URL"]


### PR DESCRIPTION
## Summary
- ensure server loads environment variables with override
- load .env with override in OpenAI provider

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68744868272c8329a8e6c0467a7191f6