### PR TITLE
Fix .env path search

### DIFF
--- a/backend/ai_providers/openai_provider.py
+++ b/backend/ai_providers/openai_provider.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import openai
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 
 from .base import (
     TextProcessingRequest,
@@ -21,9 +21,14 @@ from .base import (
 )
 
 # Ensure environment variables are loaded even if the server did not call
-# ``load_dotenv`` for some reason. This uses the ``backend/.env`` file relative
-# to this provider module.
-load_dotenv(Path(__file__).resolve().parents[1] / ".env", override=False)
+# ``load_dotenv`` for some reason. We look for ``backend/.env`` starting from
+# the current working directory so deployments that run the code from an
+# installed package can still locate the file in the project root. ``override``
+# ensures values from the file replace any empty environment variables.
+env_path = find_dotenv("backend/.env", usecwd=True)
+if not env_path:
+    env_path = Path(__file__).resolve().parents[1] / ".env"
+load_dotenv(env_path, override=True)
 
 
 class OpenAITextProvider(TextProvider):

--- a/backend/server.py
+++ b/backend/server.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 from fastapi import APIRouter, Depends, FastAPI, File, Form, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, StreamingResponse
@@ -46,7 +46,17 @@ from .services.document_service import DocumentService
 
 # Load environment variables
 ROOT_DIR = Path(__file__).parent
-load_dotenv(ROOT_DIR / ".env")
+# Always load environment variables from ``backend/.env``. We search starting
+# from the current working directory so running the server from an installed
+# package still picks up the project's ``backend/.env``. ``override=True``
+# ensures the values from the file replace any existing environment variables
+# that may have been defined but left empty by the execution environment. This
+# prevents spurious "<VAR> environment variable not set" errors when a blank
+# variable already exists.
+env_path = find_dotenv("backend/.env", usecwd=True)
+if not env_path:
+    env_path = ROOT_DIR / ".env"
+load_dotenv(env_path, override=True)
 
 # MongoDB connection
 mongo_url = os.environ["MONGO_URL"]


### PR DESCRIPTION
## Summary
- search for backend/.env starting from the working directory
- fallback to module-relative path if not found

## Testing
- `pip install -r backend/requirements.txt` *(fails: huge downloads)*
- `pytest -q` *(fails: ModuleNotFoundError: aiofiles)*


------
https://chatgpt.com/codex/tasks/task_e_68744868272c8329a8e6c0467a7191f6