### PR TITLE
Improve env loading clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ cp frontend/.env.example frontend/.env
 # The server will refuse to start if this value is not provided. Optionally
 # adjust `ACCESS_TOKEN_EXPIRE_MINUTES`.
 # Set `ALLOWED_ORIGINS` to a comma-separated list of allowed origins for CORS.
+# Each value must be wrapped in quotes with no trailing characters, e.g.
+# `OPENAI_API_KEY="sk-..."`. Malformed lines may cause the keys to be ignored.
 ```
 
 > **Note:** If you change values in `frontend/.env` while the React development

--- a/backend/server.py
+++ b/backend/server.py
@@ -50,8 +50,10 @@ ROOT_DIR = Path(__file__).parent
 # ensures the values from the file replace any existing environment variables
 # that may have been defined but left empty by the execution environment. This
 # prevents spurious "<VAR> environment variable not set" errors when a blank
-# variable already exists.
-load_dotenv(ROOT_DIR / ".env", override=True)
+# variable already exists. ``verbose=True`` surfaces any parsing warnings so
+# misformatted lines are easier to diagnose.
+ENV_PATH = ROOT_DIR / ".env"
+load_dotenv(ENV_PATH, override=True, verbose=True)
 
 # MongoDB connection
 mongo_url = os.environ["MONGO_URL"]


### PR DESCRIPTION
## Summary
- show parse warnings when loading `.env`
- clarify README about quoting env values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68744dcf514c8329a11f6fa39e2debf6